### PR TITLE
Remove libc dependency; Fix handling of `const_cstr! { pub }`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,3 @@ description = "Create static C-compatible strings from Rust string literals."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cybergeek94/const-cstr"
 
-[dependencies]
-libc = "0.1"

--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ Example
 -------
 ```rust
  #[macro_use] extern crate const_cstr;
- // Just for the `libc::c_char` type alias.
- extern crate libc;
-     
+
+ use std::os::raw::c_char;
  use std::ffi::CStr;
 
  const_cstr! {
@@ -35,7 +34,7 @@ Example
  }
 
  // Imagine this is an `extern "C"` function linked from some other lib.
- unsafe fn print_c_string(cstr: *const libc::c_char) {
+ unsafe fn print_c_string(cstr: *const c_char) {
      println!("{}", CStr::from_ptr(cstr).to_str().unwrap());
  }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,17 +141,17 @@ impl ConstCStr {
 /// Remember that functions consuming a C-string will only see up to the first NUL byte.
 #[macro_export]
 macro_rules! const_cstr {
+    ($(pub $strname:ident = $strval:expr);+;) => (
+        $(
+            pub const $strname: $crate::ConstCStr = const_cstr!($strval);
+        )+
+    );
     ($strval:expr) => (
         $crate::ConstCStr { val: concat!($strval, "\0") }
     );
     ($($strname:ident = $strval:expr);+;) => (
         $(
             const $strname: $crate::ConstCStr = const_cstr!($strval);
-        )+
-    );
-    ($(pub $strname:ident = $strval:expr);+;) => (
-        $(
-            pub const $strname: $crate::ConstCStr = const_cstr!($strval);
         )+
     );
 }
@@ -167,3 +167,16 @@ fn test_creates_valid_str() {
     assert_eq!(HELLO_CSTR.to_str(), cstr.to_str().unwrap());
 }
 
+#[cfg(test)]
+mod test_creates_pub_str_mod {
+    const_cstr! {
+        pub FIRST = "first";
+        pub SECOND = "second";
+    }
+}
+
+#[test]
+fn test_creates_pub_str() {
+    assert_eq!(test_creates_pub_str_mod::FIRST.to_str(), "first");
+    assert_eq!(test_creates_pub_str_mod::SECOND.to_str(), "second");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,8 @@
 //!
 //! ```rust
 //! #[macro_use] extern crate const_cstr;
-//! // Just for the `libc::c_char` type alias.
-//! extern crate libc;
-//!     
+//!
+//! use std::os::raw::c_char;
 //! use std::ffi::CStr;
 //!
 //! const_cstr! {
@@ -30,7 +29,7 @@
 //! }
 //!
 //! // Imagine this is an `extern "C"` function linked from some other lib.
-//! unsafe fn print_c_string(cstr: *const libc::c_char) {
+//! unsafe fn print_c_string(cstr: *const c_char) {
 //!     println!("{}", CStr::from_ptr(cstr).to_str().unwrap());
 //! }
 //!
@@ -51,8 +50,8 @@
 //! Hello, world!
 //! Goodnight, sun!
 //! ```
-extern crate libc;
 
+use std::os::raw::c_char;
 use std::ffi::CStr;
 
 /// A type representing a static C-compatible string, wrapping `&'static str`.
@@ -100,12 +99,12 @@ impl ConstCStr {
     /// ------
     /// If the wrapped string is not NUL-terminated. 
     /// (Unlikely if you used the `const_cstr!` macro. This is just a sanity check.)
-    pub fn as_ptr(&self) -> *const libc::c_char {
+    pub fn as_ptr(&self) -> *const c_char {
         let bytes = self.val.as_bytes();
 
         assert_eq!(bytes[bytes.len() - 1], b'\0');
 
-        self.val.as_bytes().as_ptr() as *const libc::c_char
+        self.val.as_bytes().as_ptr() as *const c_char
     }
 
     /// Returns the wrapped string as an `&'static CStr`, skipping the length check that


### PR DESCRIPTION
1. 2b527d4 — Removed the libc dependency. The standard `std::os::raw::c_char` type is used instead (this should resolve to the same type of `libc::c_char`).
2. 03ade1b — As of const-cstr 0.2.1 on Rust 1.10, using `const_cstr! { pub ... }` will fail to compile with the following error:
   
   ``` rust
   error: expected expression, found keyword `pub`
      --> src/lib.rs:173:9
       |
   173 |         pub FIRST = "first";
       |         ^^^
   ```
   
   This commit fixes it by shuffling the declaration order of the macro patterns.
